### PR TITLE
Correct model name in learning check 6.1

### DIFF
--- a/06-multiple-regression.Rmd
+++ b/06-multiple-regression.Rmd
@@ -529,7 +529,7 @@ It turns out that the female instructor of age 36 taught the first four courses,
 \vspace{-0.1in}
 ```
 
-**`r paste0("(LC", chap, ".", (lc <- lc + 1), ")")`** Compute the observed values, fitted values, and residuals not for the interaction model as we just did, but rather for the parallel slopes model we saved in `score_model_interaction`.
+**`r paste0("(LC", chap, ".", (lc <- lc + 1), ")")`** Compute the observed values, fitted values, and residuals not for the interaction model as we just did, but rather for the parallel slopes model we saved in `score_model_parallel_slopes`.
 
 ```{block, type='learncheck', purl=FALSE}
 \vspace{-0.25in}


### PR DESCRIPTION
The text of learning check 6.1 refers to computing predictions for a parallel slope model, but refers to an R object named score_model_interaction, which is actually an independent slopes model.